### PR TITLE
Ignore conflicted test on S2GRAPH-148

### DIFF
--- a/s2core/src/test/scala/org/apache/s2graph/core/tinkerpop/structure/S2GraphTest.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/tinkerpop/structure/S2GraphTest.scala
@@ -41,7 +41,7 @@ class S2GraphTest extends FunSuite with Matchers with TestCommonWithModels {
   initTests()
 
   val g = new S2Graph(config)
-//  lazy val gIndex = management.buildGlobalIndex(GlobalIndex.EdgeType, "S2GraphTest2", Seq("weight"))
+  lazy val gIndex = management.buildGlobalIndex(GlobalIndex.EdgeType, "S2GraphTest2", Seq("weight"))
   def printEdges(edges: Seq[Edge]): Unit = {
     edges.foreach { edge =>
       logger.debug(s"[FetchedEdge]: $edge")
@@ -416,10 +416,9 @@ class S2GraphTest extends FunSuite with Matchers with TestCommonWithModels {
 ////      }
 ////    }
 //  }
-  test("Modern") {
-//    gIndex
+  ignore("Modern") {
+    gIndex
     val mnt = graph.management
-
 
     S2GraphFactory.cleanupDefaultSchema
     S2GraphFactory.initDefaultSchema(graph)


### PR DESCRIPTION
- In the code below, the `addVertex, addEdge` method calls `indexProvider.mutate {Edge, Vertex}`
- `indexProvider.mutate {Edge, Vertex}`  method is calls `GlobalIndex.findAll` for find correct Globalndex

In this case, the value cached by the `GlobalIndex.findAll` method affects the `GlobalIndexTest` causing the test to fail randomly.

Modify the test to ignore it.

```scala
// s2core/src/test/scala/org/apache/s2graph/core/tinkerpop/structure/S2GraphTest.scala

test("modern") { 
    ...    
    val v1 = graph.addVertex(T.label, "person", T.id, Int.box(1), "name", "marko", "age", Int.box(29))  
    
    ...
    val e1 = v1.addEdge("created", v3, "weight", Double.box(0.4))
    ...
}
```