### PR TITLE
Remove type parameter on Storage Trait

### DIFF
--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/SKeyValue.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/SKeyValue.scala
@@ -56,18 +56,17 @@ trait CanSKeyValue[T] {
 }
 
 object CanSKeyValue {
-
-  // For asyncbase KeyValues
-  implicit val asyncKeyValue = new CanSKeyValue[KeyValue] {
-    def toSKeyValue(kv: KeyValue): SKeyValue = {
-      SKeyValue(Array.empty[Byte], kv.key(), kv.family(), kv.qualifier(), kv.value(), kv.timestamp())
-    }
+  def instance[T](f: T => SKeyValue): CanSKeyValue[T] = new CanSKeyValue[T] {
+    override def toSKeyValue(from: T): SKeyValue = f.apply(from)
   }
 
   // For asyncbase KeyValues
-  implicit val sKeyValue = new CanSKeyValue[SKeyValue] {
-    def toSKeyValue(kv: SKeyValue): SKeyValue = kv
+  implicit val asyncKeyValue = instance[KeyValue] { kv =>
+    SKeyValue(Array.empty[Byte], kv.key(), kv.family(), kv.qualifier(), kv.value(), kv.timestamp())
   }
+
+  // For asyncbase KeyValues
+  implicit val sKeyValue = instance[SKeyValue](identity)
 
   // For hbase KeyValues
 }

--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/WriteWriteConflictResolver.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/WriteWriteConflictResolver.scala
@@ -32,7 +32,7 @@ class WriteWriteConflictResolver(graph: S2Graph,
                                  serDe: StorageSerDe,
                                  io: StorageIO,
                                  mutator: StorageWritable,
-                                 fetcher: StorageReadable[_]) {
+                                 fetcher: StorageReadable) {
 
   val BackoffTimeout = graph.BackoffTimeout
   val MaxRetryNum = graph.MaxRetryNum
@@ -69,7 +69,7 @@ class WriteWriteConflictResolver(graph: S2Graph,
         case FetchTimeoutException(retryEdge) =>
           logger.info(s"[Try: $tryNum], Fetch fail.\n${retryEdge}")
           /* fetch failed. re-fetch should be done */
-          fetcher.fetchSnapshotEdgeInner(edges.head).flatMap { case (queryParam, snapshotEdgeOpt, kvOpt) =>
+          fetcher.fetchSnapshotEdgeInner(edges.head).flatMap { case (snapshotEdgeOpt, kvOpt) =>
             retry(tryNum + 1)(edges, statusCode, snapshotEdgeOpt)
           }
 
@@ -91,7 +91,7 @@ class WriteWriteConflictResolver(graph: S2Graph,
               val future = if (failedStatusCode == 0) {
                 // acquire Lock failed. other is mutating so this thead need to re-fetch snapshotEdge.
                 /* fetch failed. re-fetch should be done */
-                fetcher.fetchSnapshotEdgeInner(edges.head).flatMap { case (queryParam, snapshotEdgeOpt, kvOpt) =>
+                fetcher.fetchSnapshotEdgeInner(edges.head).flatMap { case (snapshotEdgeOpt, kvOpt) =>
                   retry(tryNum + 1)(edges, statusCode, snapshotEdgeOpt)
                 }
               } else {

--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/hbase/AsynchbaseStorage.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/hbase/AsynchbaseStorage.scala
@@ -27,7 +27,6 @@ import com.typesafe.config.Config
 import org.apache.commons.io.FileUtils
 import org.apache.s2graph.core._
 import org.apache.s2graph.core.storage._
-import org.apache.s2graph.core.storage.hbase.AsynchbaseStorage.AsyncRPC
 import org.apache.s2graph.core.utils._
 import org.hbase.async._
 import org.apache.s2graph.core.storage.serde._
@@ -140,7 +139,7 @@ object AsynchbaseStorage {
 
 
 class AsynchbaseStorage(override val graph: S2Graph,
-                        override val config: Config) extends Storage[AsyncRPC](graph, config) {
+                        override val config: Config) extends Storage(graph, config) {
 
   /**
     * since some runtime environment such as spark cluster has issue with guava version, that is used in Asynchbase.
@@ -156,7 +155,7 @@ class AsynchbaseStorage(override val graph: S2Graph,
 
   override val serDe: StorageSerDe = new AsynchbaseStorageSerDe(graph)
 
-  override val fetcher: StorageReadable[AsyncRPC] = new AsynchbaseStorageReadable(graph, config, client, serDe, io)
+  override val fetcher: StorageReadable = new AsynchbaseStorageReadable(graph, config, client, serDe, io)
 
   //  val hbaseExecutor: ExecutorService  =
   //    if (config.getString("hbase.zookeeper.quorum") == "localhost")


### PR DESCRIPTION
Overall it seems to be a good refactoring to organize the layers.

During review, the [Q] Type parameter used for Storage Trait seems unnecessary.

Because each `RPC` is used only in the concrete implementation and is not exposed.

For the TypeParameter(Q) to be useful, some implementations(eg: FetchXXX) should be provided using buildRequest.

I made a PR that removed it.

Please review.