### PR TITLE
[S2GRAPH-193] add extra jars to launch spark job

### DIFF
--- a/example/import_data.sh
+++ b/example/import_data.sh
@@ -24,9 +24,11 @@ JOBDESC_TPL=${WORKDIR}/${SERVICE}/jobdesc.template
 JOBDESC=${WORKDIR}/${SERVICE}/jobdesc.json
 WORKING_DIR=`pwd`
 JAR=`ls ${ROOTDIR}/s2jobs/target/scala-2.11/s2jobs-assembly*.jar`
+LIB=`cd ${ROOTDIR}/target/apache-s2graph-*-incubating-bin/lib; pwd`
 
 info "WORKING_DIR : $WORKING_DIR"
 info "JAR : $JAR"
+info "LIB : $LIB"
 
 sed -e "s/\[=WORKING_DIR\]/${WORKING_DIR//\//\\/}/g" $JOBDESC_TPL | grep "^[^#]" > $JOBDESC
 
@@ -35,6 +37,8 @@ info "spark submit.."
 ${SPARK_HOME}/bin/spark-submit \
   --class org.apache.s2graph.s2jobs.JobLauncher \
   --master local[2] \
-  --driver-class-path h2-1.4.192.jar \
-  $JAR file -f $JOBDESC -n SAMPLEJOB:$SERVICE
+  --jars $LIB/h2-1.4.192.jar,$LIB/lucene-core-7.1.0.jar \
+  --driver-class-path "$LIB/h2-1.4.192.jar:$LIB/lucene-core-7.1.0.jar" \
+  --driver-java-options "-Dderby.system.home=/tmp/derby" \
+  $JAR file -f $JOBDESC -n SAMPLEJOB:$SERVICE 
 

--- a/example/prepare.sh
+++ b/example/prepare.sh
@@ -22,6 +22,9 @@ status=`curl -s -o /dev/null -w "%{http_code}" "$REST"`
 if [ $status != '200' ]; then
     warn "s2graphql not running.. "
 
+    wget https://raw.githubusercontent.com/daewon/sangria-akka-http-example/master/src/main/resources/assets/graphiql.html
+    mv graphiql.html $ROOTDIR/s2graphql/src/main/resources/assets
+
     cd $ROOTDIR
     output="$(ls target/apache-s2graph-*-incubating-bin)"   
     if [ -z "$output" ]; then
@@ -31,7 +34,7 @@ if [ $status != '200' ]; then
 
     info "now we will launch s2graphql using build scripts"
     cd target/apache-s2graph-*-incubating-bin
-    ./bin/start-s2graph.sh s2graphql
+    sh ./bin/start-s2graph.sh s2graphql
 else
     info "s2graphql is running!!"
 fi 

--- a/example/prepare.sh
+++ b/example/prepare.sh
@@ -22,9 +22,6 @@ status=`curl -s -o /dev/null -w "%{http_code}" "$REST"`
 if [ $status != '200' ]; then
     warn "s2graphql not running.. "
 
-    wget https://raw.githubusercontent.com/daewon/sangria-akka-http-example/master/src/main/resources/assets/graphiql.html
-    mv graphiql.html $ROOTDIR/s2graphql/src/main/resources/assets
-
     cd $ROOTDIR
     output="$(ls target/apache-s2graph-*-incubating-bin)"   
     if [ -z "$output" ]; then
@@ -34,6 +31,9 @@ if [ $status != '200' ]; then
 
     info "now we will launch s2graphql using build scripts"
     cd target/apache-s2graph-*-incubating-bin
+    wget https://raw.githubusercontent.com/daewon/sangria-akka-http-example/master/src/main/resources/assets/graphiql.html
+    mkdir -p conf/assets
+    mv graphiql.html conf/assets
     sh ./bin/start-s2graph.sh s2graphql
 else
     info "s2graphql is running!!"


### PR DESCRIPTION
I fixed an error that caused the following exception when executing a spark job:
```
java.sql.SQLException: No suitable driver found for jdbc:h2:tcp://localhost/./var/metastore;MODE=MYSQL
	at java.sql.DriverManager.getConnection(DriverManager.java:689)
	at java.sql.DriverManager.getConnection(DriverManager.java:247)
	at org.apache.commons.dbcp.DriverManagerConnectionFactory.createConnection(DriverManagerConnectionFactory.java:75)
	at org.apache.commons.dbcp.PoolableConnectionFactory.makeObject(PoolableConnectionFactory.java:582)
	at org.apache.commons.pool.impl.GenericObjectPool.borrowObject(GenericObjectPool.java:1148)
	at org.apache.commons.dbcp.PoolingDataSource.getConnection(PoolingDataSource.java:106)
	at scalikejdbc.CommonsConnectionPool.borrow(CommonsConnectionPool.scala:58)
	at scalikejdbc.ConnectionPool$.borrow(ConnectionPool.scala:225)
	at org.apache.s2graph.core.mysqls.Model$.withTx(Model.scala:98)
	at org.apache.s2graph.core.mysqls.Model$.checkSchema(Model.scala:69)
	at org.apache.s2graph.core.mysqls.Model$.apply(Model.scala:63)
	at org.apache.s2graph.core.S2Graph.<init>(S2Graph.scala:184)
	at org.apache.s2graph.s2jobs.S2GraphHelper$.getS2Graph(S2GraphHelper.scala:38)
```